### PR TITLE
fix typo

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -84,7 +84,7 @@
         ]
       }
     ],
-    "group":{
+    "groups":{
       "partnercenter-1.8.1":{
         "dest":"partnercenter-1.8.1",
         "moniker_range":"partnercenter-1.8.1"


### PR DESCRIPTION
we should use "groups" instead of "group"