### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -112,7 +112,7 @@
       "uhfHeaderId": "MSDocsHeader-Partner-Center",
       "apiPlatform": "java",
       "author": "isaiahwilliams",
-      "breadcrumb_path": "/java/partnercenter-java_breadcrumb/toc.json",
+      "breadcrumb_path": "/java/partner-center-breadcrumb/toc.json",
       "ms.author": "iswillia",
       "manager": "jasonh",
       "ms.topic": "reference",

--- a/docfx.json
+++ b/docfx.json
@@ -20,7 +20,7 @@
           "toc.yml"
         ],
         "src": "partner-center-breadcrumb",
-        "dest": "partnercenter-java_breadcrumb",
+        "dest": "partner-center-breadcrumb",
         "exclude": [
           "**/obj/**",
           "**/includes/**"

--- a/partner-center-breadcrumb/toc.yml
+++ b/partner-center-breadcrumb/toc.yml
@@ -1,4 +1,7 @@
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: Partner Center
+  tocHref: /java/
+  topicHref: /partner-center/index
   items:
+  - name: Java API browser
+    tocHref: /java/
+    topicHref: /java/api/index


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings and if PR Automerger service is available for this repo. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation.